### PR TITLE
Added htmlToPrism convertor

### DIFF
--- a/app/views/declaration.html
+++ b/app/views/declaration.html
@@ -61,22 +61,23 @@
               <div class="tab-pane" style="display: block;">
                 <pre class="language-markup">
                   <code>
-  &lt;h1 class="heading-xlarge"&gt;Declaration&lt;/h1&gt;
+                    {{         htmlToPrism('<h1 class="heading-xlarge">Declaration</h1>
 
-  &lt;p class="text"&gt;By sending the application you agree that:&lt;/p&gt;
+                    <p class="text">By sending the application you agree that:</p>
 
-  &lt;ul class="list-bullet"&gt;
-    &lt;li&gt;the information is correct and complete as far as you know&lt;/li&gt;
-    &lt;li&gt;you'll pay back any money you're overpaid if you're asked to&lt;/li&gt;
-  &lt;/ul&gt;
+                    <ul class="list-bullet">
+                      <li>the information is correct and complete as far as you know</li>
+                      <li>you\'ll pay back any money you\'re overpaid if you\'re asked to</li>
+                    </ul>
 
-  &lt;div class="legal_message"&gt;
-    You could be prosecuted or have to pay a financial penalty if you
-    deliberately give the wrong or incomplete information or don't
-    report changes.
-  &lt;/div&gt;
+                    <div class="legal_message">
+                      You could be prosecuted or have to pay a financial penalty if you
+                      deliberately give the wrong or incomplete information or don\'t
+                      report changes.
+                    </div>
 
-  &lt;p&gt;&lt;a href="#" class="button"&gt;I agree - send my application&lt;/a&gt;&lt;/p&gt;
+                    <p><a href="#" class="button">I agree - send my application</a></p>') }}
+
                   </code>
                 </pre>
               </div>
@@ -169,36 +170,47 @@
             <div class="tab-pane" style="display: block;">
               <pre class="language-markup">
                 <code>
-      &lt;h1 class="heading-xlarge"&gt;Consent and declaration&lt;/h1&gt;
+                  {{         htmlToPrism('<h1 class="heading-xlarge">Consent and declaration</h1>
 
-      &lt;form&gt;
-        &lt;fieldset class="inline"&gt;
-          &lt;legend&gt;Do you agree to the Carer's Allowance unit contacting anyone mentioned in this form?&lt;/legend&gt;
-          &lt;label class="block-label" for="radio-inline-1"&gt;
-            &lt;input id="radio-inline-1" type="radio" name="radio-inline-group" value="Yes"&gt;
-            Yes
-          &lt;/label&gt;
+                      <form>
+                        <fieldset class="inline">
+                          <legend>
+                            Do you agree to the Carer\'s Allowance unit contacting anyone
+                            mentioned in this form?
+                          </legend>
 
-          &lt;label class="block-label" for="radio-inline-2"&gt;
-            &lt;input id="radio-inline-2" type="radio" name="radio-inline-group" value="No"&gt;
-            No
-          &lt;/label&gt;
-        &lt;/fieldset&gt;
+                          <label class="block-label" for="radio-inline-1">
+                            <input id="radio-inline-1" type="radio" name="radio-inline-group" value="Yes">
+                            Yes
+                          </label>
 
-        &lt;p class="text"&gt;By sending the application you agree that:&lt;/p&gt;
+                          <label class="block-label" for="radio-inline-2">
+                            <input id="radio-inline-2" type="radio" name="radio-inline-group" value="No">
+                            No
+                          </label>
+                        </fieldset>
 
-        &lt;ul class="list-bullet"&gt;
-          &lt;li&gt;the information is correct and complete as far as you know&lt;/li&gt;
-          &lt;li&gt;you'll pay back any money you're overpaid if you're asked to&lt;/li&gt;
-          &lt;li&gt;you'll report changes of circumstances or those of the person you care for promptly either &lt;a href="" rel="external"&gt;online&lt;/a&gt; or by contacting the &lt;a href="" rel="external"&gt;Carer's Allowance Unit&lt;/a&gt;.&lt;/li&gt;
-        &lt;/ul&gt;
+                        <p class="text">By sending the application you agree that:</p>
 
-        &lt;div class="legal_message"&gt;
-          You could be prosecuted or have to pay a financial penalty if you deliberately give the wrong or incomplete information or don't report changes. Your Carer's allowance may also be stopped or reduced.
-        &lt;/div&gt;
+                        <ul class="list-bullet">
+                          <li>the information is correct and complete as far as you know</li>
+                          <li>you\'ll pay back any money you\'re overpaid if you\'re asked to</li>
+                          <li>
+                            you\'ll report changes of circumstances or those of the person you
+                            care for promptly either <a href="" rel="external">online</a> or
+                            by contacting the <a href="" rel="external">Carer\'s Allowance Unit</a>.
+                          </li>
+                        </ul>
 
-        &lt;input type="button" value="I agree - send my application" class="button"&gt;
-      &lt;/form&gt;
+                        <div class="legal_message">
+                          You could be prosecuted or have to pay a financial penalty if you
+                          deliberately give the wrong or incomplete information or don\'t
+                          report changes. Your Carer\'s allowance may also be stopped or reduced.
+                        </div>
+
+                        <input type="button" value="I agree - send my application" class="button">
+                      </form>') }}
+
                 </code>
               </pre>
             </div>

--- a/server.js
+++ b/server.js
@@ -67,11 +67,18 @@ app.use(function (req, res, next) {
   next();
 });
 
+function htmlToPrism(text){
+  text.replace('<','&lt;');
+  text.replace('>','&rt;');
+  return text;
+}
+
 // Add variables that are available in all views
 app.use(function (req, res, next) {
   _.merge(res.locals,{
     serviceName: config.serviceName,
     cookieText: config.cookieText,
+    htmlToPrism: htmlToPrism,
     releaseVersion: 'v' + releaseVersion,
     postData: (req.body ? req.body : false)
   });


### PR DESCRIPTION
This allows you to convert html to standard markup for prism.

eg:
```
  
{{ htmlToPrism('<h1 class="heading-xlarge">hello</h1>') }}

```

Any quotes will need to be escaped i.e:

```
  
{{ htmlToPrism('<h1 class="heading-xlarge">Dave\'s house</h1>') }}

```